### PR TITLE
Fix for search over virtual attributes (like searchable_content in locomotivecms_search)

### DIFF
--- a/lib/activesearch/mongoid/model.rb
+++ b/lib/activesearch/mongoid/model.rb
@@ -27,18 +27,24 @@ module ActiveSearch
       end
       
       def refresh_keywords(original, fields)
-        self._keywords = fields.map do |f|
+        self._keywords = []
+
+        fields.each do |f|
           
           if original.fields[f.to_s] && original.fields[f.to_s].localized?
             original.send("#{f}_translations").reject { |l, t| t.nil? }.map do |locale, translation|
-              translation.downcase.split.map { |word| "#{locale}:#{word}"}
-            end.flatten
+              translation.downcase.split.each do |word|  
+                self._keywords << "#{locale}:#{word}"
+              end
+            end
           else
-            [original.try(f)].flatten.reject(&:nil?).map(&:downcase).map(&:split).flatten
+            [original.try(f)].flatten.compact.map(&:downcase).map(&:split).flatten.each do |word|
+              self._keywords << word
+            end 
           end
-        end.flatten
+          
+        end
 
-        
         self._keywords.map! { |k| ActiveSearch.strip_tags(k) }
         self._keywords.uniq!
       end

--- a/lib/activesearch/mongoid/model.rb
+++ b/lib/activesearch/mongoid/model.rb
@@ -27,27 +27,6 @@ module ActiveSearch
       end
       
       def refresh_keywords(original, fields)
-        # self._keywords = fields.select { |f| original.respond_to? f }.inject([]) do |memo,f|
-        #   
-        #   if original.fields[f.to_s].localized?
-        #     memo += original.send("#{f}_translations").map do |locale,translation|
-        #       next if translation.nil?
-        #       translation.downcase.split.map { |word| "#{locale}:#{word}"}
-        #     end.flatten
-        #   else
-        #     if original[f]
-        #       memo += if original[f].is_a?(Array)
-        #         original[f].map { |value| value.nil? ? nil : value.downcase }
-        #       else
-        #         original[f].downcase.split
-        #       end
-        #       
-        #     else
-        #       memo
-        #     end
-        #   end
-        # end
-
         self._keywords = fields.map do |f|
           
           if original.fields[f.to_s] && original.fields[f.to_s].localized?


### PR DESCRIPTION
This fixes the issue when searchable_content set in locomotivecms_search was just ignored as it's not really field of model.
